### PR TITLE
Add `netlify.toml` to Enable SPA Routing Support – Closes #24

### DIFF
--- a/backend/contributors.json
+++ b/backend/contributors.json
@@ -1,5 +1,5 @@
 {
-  "fetched_at": 1753290562.8773108,
+  "fetched_at": 1753332276.681953,
   "data": [
     {
       "login": "whyvineet",
@@ -21,7 +21,7 @@
       "type": "User",
       "user_view_type": "public",
       "site_admin": false,
-      "contributions": 15
+      "contributions": 17
     },
     {
       "login": "deepanshu-prajapati01",
@@ -43,7 +43,7 @@
       "type": "User",
       "user_view_type": "public",
       "site_admin": false,
-      "contributions": 2
+      "contributions": 3
     },
     {
       "login": "vinay-sikarwar",

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
## 🐛 Problem Summary

As reported in Issue #24, navigating directly to internal routes (e.g., `/our-contributors`) on the deployed Netlify site results in a **404 Not Found** error.

🔗 Live site:  
https://orthoplay.netlify.app/

🔴 Example of broken route:  
https://orthoplay.netlify.app/our-contributors

This issue arises because Netlify does not handle client-side routing in SPAs (like React apps) unless explicitly configured.