### PR TITLE
feat: add difficulty level popup options(Easy,Medium,Hard)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -183,6 +183,30 @@ const OrthoplayGame = () => {
     });
   };
 
+  const startGameWithDifficulty = async (difficulty) => {
+    setIsLoading(true);
+    setErrorMessage('');
+
+    try {
+      const data = await apiService.startGame(difficulty);
+      setCurrentGame({
+        wordId: data.word_id,
+        word: data.word,
+        description: data.description,
+        lengthOptions: data.length_options,
+      });
+
+      setGameState('playing');
+      setGamePhase('length');
+      resetGameData();
+    } catch (error) {
+      console.error('Error starting game:', error);
+      showError(`Failed to start game: ${error.message}`);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   const gameProps = {
     gameState,
     gamePhase,
@@ -218,7 +242,7 @@ const OrthoplayGame = () => {
       <Navigation apiStatus={apiStatus} />
 
       <main className='min-h-screen'>
-        {gameState === 'start' && <StartPage {...gameProps} />}
+        {gameState === 'start' && <StartPage {...gameProps} startGameWithDifficulty={startGameWithDifficulty} />}
         {gameState === 'playing' && <GamePage {...gameProps} />}
         {gameState === 'complete' && <CompletePage {...gameProps} />}
       </main>

--- a/frontend/src/components/DifficultyPopup.jsx
+++ b/frontend/src/components/DifficultyPopup.jsx
@@ -1,0 +1,41 @@
+import React from "react";
+
+const DifficultyPopup = ({ isOpen, onSelect, onClose }) => {
+  if (!isOpen) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center backdrop-blur-sm bg-opacity-40">
+      <div className="bg-white rounded-2xl shadow-2xl p-8 w-full max-w-xs text-center relative">
+        <h2 className="text-2xl font-bold mb-6 text-gray-900">Select Difficulty</h2>
+        <div className="flex flex-col gap-4 mb-4  ">
+          <button
+            className="px-6 py-3 bg-green-500 ring-2  text-white font-semibold rounded-xl hover:bg-green-600 transition-all"
+            onClick={() => onSelect("easy")}
+          >
+            Easy
+          </button>
+          <button
+            className="px-6 py-3 bg-yellow-500 text-white font-semibold rounded-xl hover:bg-yellow-600 transition-all"
+            onClick={() => onSelect("medium")}
+          >
+            Medium
+          </button>
+          <button
+            className="px-6 py-3 bg-red-500 text-white font-semibold rounded-xl hover:bg-red-600 transition-all"
+            onClick={() => onSelect("hard")}
+          >
+            Hard
+          </button>
+        </div>
+        <button
+          className="absolute top-2 right-2 text-gray-400 hover:text-gray-700 text-xl font-bold"
+          onClick={onClose}
+          aria-label="Close"
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default DifficultyPopup;

--- a/frontend/src/pages/StartPage.jsx
+++ b/frontend/src/pages/StartPage.jsx
@@ -1,6 +1,19 @@
+import { useState } from "react";
 import { Volume2, CheckCircle, XCircle } from "lucide-react";
+import DifficultyPopup from "../components/DifficultyPopup";
 
-const StartPage = ({ isLoading, startGame, apiStatus }) => {
+const StartPage = ({ isLoading, startGameWithDifficulty, apiStatus }) => {
+  const [showPopup, setShowPopup] = useState(false);
+
+  const handleStartClick = () => {
+    setShowPopup(true);
+  };
+
+  const handleSelectDifficulty = (difficulty) => {
+    setShowPopup(false);
+    startGameWithDifficulty(difficulty);
+  };
+
   return (
     <div className="min-h-screen bg-gradient-to-br pt-12 from-slate-50 to-blue-50">
       <div className="container mx-auto">
@@ -38,7 +51,7 @@ const StartPage = ({ isLoading, startGame, apiStatus }) => {
             </div>
 
             <button
-              onClick={startGame}
+              onClick={handleStartClick}
               disabled={isLoading}
               className="inline-flex items-center justify-center px-8 py-4 bg-blue-600 text-white text-lg font-semibold rounded-2xl hover:bg-blue-700 transition-all duration-200 shadow-lg hover:shadow-xl disabled:opacity-50 disabled:cursor-not-allowed min-w-48"
             >
@@ -67,7 +80,11 @@ const StartPage = ({ isLoading, startGame, apiStatus }) => {
             </div>
           </div>
         </div>
-
+        <DifficultyPopup
+          isOpen={showPopup}
+          onSelect={handleSelectDifficulty}
+          onClose={() => setShowPopup(false)}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
- Implemented a new UI container to allow users to select difficulty levels (Easy, Medium, Hard) before starting the game.

- Updated words.json to include difficulty tags for each word.

- Modified backend logic to fetch words based on the selected difficulty level.

- Ensures that when a user selects "Hard", only words tagged as hard are used in the game, and similarly for "Easy" and "Medium".

This enhancement improves game personalization and user experience. 🚀