### PR TITLE
Add Demo Round Button to HowToPlay Page for Practice Gameplay

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -7,6 +7,7 @@ from datetime import datetime
 
 class GameStartRequest(BaseModel):
     difficulty: Optional[str] = "medium"
+    mode: Optional[str] = "playing"
 
 
 class GameStartResponse(BaseModel):

--- a/backend/app/routes.py
+++ b/backend/app/routes.py
@@ -76,7 +76,8 @@ async def health_check():
 async def start_game(request: GameStartRequest):
     """Start a new game session."""
     try:
-        game_data = game_service.start_game()
+        mode = request.mode
+        game_data = game_service.start_game(mode=mode)
         word_data = game_data["word_data"]
         
         length_options = game_service.generate_length_options(len(game_data["word"]))
@@ -250,6 +251,9 @@ async def submit_score(request: SubmitScoreRequest):
         session = game_service.get_session(request.word_id)
         if not session:
             raise HTTPException(status_code=404, detail="Game session not found")
+        
+        if session.get("mode") == "demo":
+            raise HTTPException(status_code=400, detail="Demo games cannot submit scores")
 
         if not session.get("completed", False):
             raise HTTPException(status_code=400, detail="Game not completed yet")

--- a/backend/app/services.py
+++ b/backend/app/services.py
@@ -36,18 +36,19 @@ class GameService:
         self.word_service = WordService()
         self.game_sessions = {}
 
-    def start_game(self) -> Dict:
+    def start_game(self, mode="playing") -> Dict:
         """Start a new game session."""
         word = self.word_service.get_random_word()
         session_id = f"game_{random.randint(1000, 9999)}"
 
-        self.game_sessions[session_id] = {
-            "word": word,
-            "attempts": 0,
-            "completed": False,
-            "hints_used": 0,
-            "start_time": time.time()
-        }
+        if mode == "playing":
+            self.game_sessions[session_id] = {
+                "word": word,
+                "attempts": 0,
+                "completed": False,
+                "hints_used": 0,
+                "start_time": time.time()
+            }
 
         return {
             "session_id": session_id,

--- a/frontend/src/pages/CompletePage.jsx
+++ b/frontend/src/pages/CompletePage.jsx
@@ -12,6 +12,7 @@ const CompletePage = ({
   numberOfHints,
   resetGame,
   getGameCompletionData,
+  lastGameMode,
 }) => {
   const [isPlayingAudio, setIsPlayingAudio] = useState(false);
   const [speechSupported, setSpeechSupported] = useState(false);
@@ -58,44 +59,44 @@ const CompletePage = ({
   
   return (
     <div className={`min-h-screen flex flex-col ${
-      darkMode 
-        ? 'bg-gradient-to-br from-gray-900 to-blue-900' 
-        : 'bg-gradient-to-br from-slate-50 to-blue-50'
-    }`}>
+      darkMode
+      ? 'bg-gradient-to-br from-gray-900 to-blue-900'
+      : 'bg-gradient-to-br from-slate-50 to-blue-50'
+      }`}>
       <div className="container mx-auto px-4 py-8 flex-grow">
         {/* Header */}
         <header className="text-center mb-8">
           <h1 className={`text-4xl font-bold mb-2 transition-colors duration-300 hover:text-blue-600 ${
             darkMode ? 'text-gray-100' : 'text-gray-900'
-          }`}>Orthoplay</h1>
+            }`}>Orthoplay</h1>
         </header>
         <div className="max-w-2xl mx-auto">
           <div className={`rounded-3xl shadow-xl p-12 text-center hover:shadow-2xl transition-all duration-300 hover:scale-[1.02] ${
-            darkMode 
-              ? 'bg-gray-800 border border-gray-700' 
-              : 'bg-white border border-gray-100'
-          }`}>
+            darkMode
+            ? 'bg-gray-800 border border-gray-700'
+            : 'bg-white border border-gray-100'
+            }`}>
             <div className="mb-8">
               <div
                 className={`inline-flex items-center justify-center w-20 h-20 rounded-full mb-6 transition-all duration-300 hover:scale-110 group ${
-                  isWinner 
-                    ? (darkMode ? 'bg-green-900 hover:bg-green-800' : 'bg-green-100 hover:bg-green-200')
-                    : (darkMode ? 'bg-orange-900 hover:bg-orange-800' : 'bg-orange-100 hover:bg-orange-200')
-                }`}
+                  isWinner
+                  ? (darkMode ? 'bg-green-900 hover:bg-green-800' : 'bg-green-100 hover:bg-green-200')
+                  : (darkMode ? 'bg-orange-900 hover:bg-orange-800' : 'bg-orange-100 hover:bg-orange-200')
+                  }`}
               >
                 {isWinner ? (
                   <Trophy className={`h-10 w-10 transition-transform duration-300 group-hover:scale-110 group-hover:rotate-12 ${
                     darkMode ? 'text-green-400' : 'text-green-600'
-                  }`} />
+                    }`} />
                 ) : (
                   <Frown className={`h-10 w-10 transition-transform duration-300 group-hover:scale-110 ${
                     darkMode ? 'text-orange-400' : 'text-orange-600'
-                  }`} />
+                    }`} />
                 )}
               </div>
               <h2 className={`text-3xl font-bold mb-4 transition-colors duration-300 hover:text-blue-600 ${
                 darkMode ? 'text-gray-100' : 'text-gray-900'
-              }`}>
+                }`}>
                 {isWinner ? 'Congratulations!' : 'Better luck next time!'}
               </h2>
             </div>
@@ -103,17 +104,17 @@ const CompletePage = ({
             <div className="mb-8">
               <p className={`text-2xl font-bold mb-2 ${
                 darkMode ? 'text-gray-100' : 'text-gray-900'
-              }`}>
+                }`}>
                 The word was:{" "}
                 <span className={darkMode ? 'text-blue-400' : 'text-blue-600'}>
                   {correctWord.toUpperCase()}
                 </span>
               </p>
               <p className={`text-lg italic mb-6 transition-colors duration-300 ${
-                darkMode 
-                  ? 'text-gray-300 hover:text-gray-200' 
-                  : 'text-gray-600 hover:text-gray-700'
-              }`}>
+                darkMode
+                ? 'text-gray-300 hover:text-gray-200'
+                : 'text-gray-600 hover:text-gray-700'
+                }`}>
                 "{exampleSentence}"
               </p>
 
@@ -121,10 +122,10 @@ const CompletePage = ({
                 onClick={playAudio}
                 disabled={!speechSupported || isPlayingAudio}
                 className={`inline-flex items-center justify-center px-6 py-3 text-white font-semibold rounded-xl hover:scale-105 hover:shadow-xl transition-all duration-300 shadow-md disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100 disabled:hover:shadow-md mb-6 active:scale-95 group ${
-                  darkMode 
-                    ? 'bg-blue-700 hover:bg-blue-600' 
-                    : 'bg-blue-600 hover:bg-blue-700'
-                }`}
+                  darkMode
+                  ? 'bg-blue-700 hover:bg-blue-600'
+                  : 'bg-blue-600 hover:bg-blue-700'
+                  }`}
               >
                 <Volume2 className="h-5 w-5 mr-2" />
                 {isPlayingAudio ? "Playing..." : "Hear Word"}
@@ -133,17 +134,17 @@ const CompletePage = ({
 
             <div className="mb-8">
               <p className={`text-lg transition-colors duration-300 ${
-                darkMode 
-                  ? 'text-gray-300 hover:text-gray-200' 
-                  : 'text-gray-600 hover:text-gray-700'
-              }`}>
+                darkMode
+                ? 'text-gray-300 hover:text-gray-200'
+                : 'text-gray-600 hover:text-gray-700'
+                }`}>
                 {isWinner
                   ? `You solved it in ${attempts} attempts!`
                   : `You tried ${attempts} times - keep practicing!`}
               </p>
               <p className={`text-lg ${
                 darkMode ? 'text-gray-300' : 'text-gray-600'
-              }`}>
+                }`}>
                 {isWinner
                   ? `You used ${numberOfHints} hints! Great Work!!`
                   : `You used ${numberOfHints} hints - better luck next time!`}
@@ -151,33 +152,55 @@ const CompletePage = ({
             </div>
 
             {/* Score Submission Section */}
-            {isWinner && !showScoreSubmission && !submissionComplete && gameCompletionData && (
-              <div className="mb-6">
-                <button
-                  onClick={handleSubmitScore}
-                  className={`inline-flex items-center justify-center px-6 py-3 text-white font-semibold rounded-xl hover:scale-105 hover:shadow-xl transition-all duration-300 shadow-md mr-4 active:scale-95 group ${
+            { 
+              lastGameMode == "demo" ? (
+                <>
+                  <p className={`mb-6 text-center font-semibold ${darkMode ? 'text-yellow-400' : 'text-yellow-700'
+                    }`}>
+                    Demo complete, ready for the full experience!
+                  </p>
+                  <button
+                    onClick={resetGame}
+                    className={`inline-flex items-center justify-center px-8 py-4 text-white text-lg font-semibold rounded-2xl hover:scale-105 hover:shadow-2xl transition-all duration-300 shadow-lg active:scale-95 mx-auto ${darkMode
+                      ? 'bg-blue-700 hover:bg-blue-600'
+                      : 'bg-blue-600 hover:bg-blue-700'
+                      }`}
+                  >
+                    Start Game
+                  </button>
+                </>
+              ) : (
+                <>
+                  {isWinner && !showScoreSubmission && !submissionComplete && gameCompletionData && (
+                    <div className="mb-6">
+                      <button
+                        onClick={handleSubmitScore}
+                        className={`inline-flex items-center justify-center px-6 py-3 text-white font-semibold rounded-xl hover:scale-105 hover:shadow-xl transition-all duration-300 shadow-md mr-4 active:scale-95 group ${
                     darkMode
-                      ? 'bg-green-700 hover:bg-green-600'
-                      : 'bg-green-600 hover:bg-green-700'
-                  }`}
-                >
-                  <Trophy className="h-5 w-5 mr-2 transition-transform duration-300 group-hover:scale-110" />
-                  Submit Score
-                </button>
-              </div>
-            )}
+                          ? 'bg-green-700 hover:bg-green-600'
+                          : 'bg-green-600 hover:bg-green-700'
+                          }`}
+                      >
+                        <Trophy className="h-5 w-5 mr-2 transition-transform duration-300 group-hover:scale-110" />
+                        Submit Score
+                      </button>
+                    </div>
+                  )}
 
-            <button
-              onClick={resetGame}
-              className={`inline-flex items-center justify-center px-8 py-4 text-white text-lg font-semibold rounded-2xl hover:scale-105 hover:shadow-2xl transition-all duration-300 shadow-lg active:scale-95 group ${
+                  <button
+                    onClick={resetGame}
+                    className={`inline-flex items-center justify-center px-8 py-4 text-white text-lg font-semibold rounded-2xl hover:scale-105 hover:shadow-2xl transition-all duration-300 shadow-lg active:scale-95 group ${
                 darkMode
-                  ? 'bg-blue-700 hover:bg-blue-600'
-                  : 'bg-blue-600 hover:bg-blue-700'
-              }`}
-            >
-              <ArrowRight className="h-5 w-5 mr-2 transition-transform duration-300 group-hover:translate-x-1" />
-              Next Word
-            </button>
+                      ? 'bg-blue-700 hover:bg-blue-600'
+                      : 'bg-blue-600 hover:bg-blue-700'
+                      }`}
+                  >
+                    <ArrowRight className="h-5 w-5 mr-2 transition-transform duration-300 group-hover:translate-x-1" />
+                    Next Word
+                  </button>
+                </>
+              )}
+
           </div>
 
           {/* Score Submission Modal */}

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -28,9 +28,10 @@ const GamePage = ({
   setErrorMessage,
   setNumberOfHints,
   trackHintUsage,
+  gameState,
 }) => {
   const { darkMode } = useContext(ThemeContext);
-  
+
   const hints = {
     hint1: currentGame.hint1,
     hint2: currentGame.hint2,
@@ -38,99 +39,110 @@ const GamePage = ({
   };
 
   return (
-    <div className={`min-h-screen ${
-      darkMode 
-        ? "bg-gradient-to-br from-gray-900 to-blue-900" 
-        : "bg-gradient-to-br from-slate-50 to-blue-50"
-    }`}>
-      <div className="container mx-auto px-4 py-8">
-        {/* Header */}
-        <header className="text-center mb-8">
-          <h1 className={`text-4xl font-bold mb-2 ${
+    <div>
+
+      {
+      gameState === "demo" && (
+                <div className="p-4 mb-4 rounded bg-yellow-200 text-yellow-900 font-semibold">
+                  Demo Mode: Your progress won't be saved.
+                </div>
+              )}
+              
+      <div className={`min-h-screen ${darkMode
+          ? "bg-gradient-to-br from-gray-900 to-blue-900"
+          : "bg-gradient-to-br from-slate-50 to-blue-50"
+        }`}>
+        <div className="container mx-auto px-4 py-8">
+          {/* Header */}
+          <header className="text-center mb-8">
+            <h1 className={`text-4xl font-bold mb-2 ${
             darkMode ? "text-gray-100" : "text-gray-900"
-          }`}>Orthoplay</h1>
-          <div className="flex items-center justify-center text-sm">
-            <span className={`px-3 py-1 rounded-full shadow-sm ${
-              darkMode 
-                ? "bg-gray-800 text-gray-300" 
-                : "bg-white text-gray-500"
-            }`}>
-              Attempts: {attempts}
-            </span>
-          </div>
-        </header>
-
-        {/* Error Message */}
-        {errorMessage && (
-          <div className="max-w-4xl mx-auto mb-6">
-            <div className={`border rounded-2xl p-4 flex items-center shadow-sm ${
-              darkMode 
-                ? "bg-red-900/30 border-red-800" 
-                : "bg-red-50 border-red-200"
-            }`}>
-              <AlertCircle className={`h-5 w-5 mr-3 ${
-                darkMode ? "text-red-400" : "text-red-500"
-              }`} />
-              <span className={`text-sm flex-1 ${
-                darkMode ? "text-red-300" : "text-red-800"
-              }`}>
-                {errorMessage}
+              }`}>Orthoplay</h1>
+            <div className="flex items-center justify-center text-sm">
+              <span className={`px-3 py-1 rounded-full shadow-sm ${
+              darkMode
+                  ? "bg-gray-800 text-gray-300"
+                  : "bg-white text-gray-500"
+                }`}>
+                Attempts: {attempts}
               </span>
-              <button
-                onClick={() => setErrorMessage("")}
-                className={`hover:text-red-700 ml-2 ${
-                  darkMode ? "text-red-400" : "text-red-500"
-                }`}
-              >
-                <XCircle className="h-5 w-5 transition-transform duration-300 hover:scale-110" />
-              </button>
             </div>
+          </header>
+
+          {/* Error Message */}
+          {errorMessage && (
+            <div className="max-w-4xl mx-auto mb-6">
+              <div className={`border rounded-2xl p-4 flex items-center shadow-sm ${
+                darkMode
+                  ? "bg-red-900/30 border-red-800"
+                  : "bg-red-50 border-red-200"
+                }`}>
+                <AlertCircle className={`h-5 w-5 mr-3 ${
+                darkMode ? "text-red-400" : "text-red-500"
+                  }`} />
+                <span className={`text-sm flex-1 ${
+                darkMode ? "text-red-300" : "text-red-800"
+                  }`}>
+                  {errorMessage}
+                </span>
+                <button
+                  onClick={() => setErrorMessage("")}
+                  className={`hover:text-red-700 ml-2 ${
+                  darkMode ? "text-red-400" : "text-red-500"
+                    }`}
+                >
+                  <XCircle className="h-5 w-5 transition-transform duration-300 hover:scale-110" />
+                </button>
+              </div>
+            </div>
+          )}
+
+          <div className="max-w-4xl mx-auto space-y-6">
+            <AudioPlayer currentGame={currentGame} />
+
+            <WordDescription description={currentGame.description} />
+
+            <Hints
+              hints={hints}
+              numberOfHints={numberOfHints}
+              setNumberOfHints={setNumberOfHints}
+              trackHintUsage={trackHintUsage}
+            />
+
+            {gamePhase === "length" && (
+              <LengthGuesser
+                lengthOptions={currentGame.lengthOptions}
+                lengthFeedback={lengthFeedback}
+                guessLength={guessLength}
+                isLoading={isLoading}
+              />
+            )}
+
+            {gamePhase === "spelling" && (
+              <SpellingGame
+                wordLength={wordLength}
+                currentGuess={currentGuess}
+                setCurrentGuess={setCurrentGuess}
+                submitSpelling={submitSpelling}
+                revealAnswer={revealAnswer}
+                isLoading={isLoading}
+              />
+            )}
+
+            {spellingHistory.length > 0 && (
+              <SpellingHistory
+                spellingHistory={spellingHistory}
+                lastMessage={lastMessage}
+              />
+            )}
+
+            <GameLegend />
           </div>
-        )}
-
-        <div className="max-w-4xl mx-auto space-y-6">
-          <AudioPlayer currentGame={currentGame} />
-
-          <WordDescription description={currentGame.description} />
-
-          <Hints
-            hints={hints}
-            numberOfHints={numberOfHints}
-            setNumberOfHints={setNumberOfHints}
-            trackHintUsage={trackHintUsage}
-          />
-
-          {gamePhase === "length" && (
-            <LengthGuesser
-              lengthOptions={currentGame.lengthOptions}
-              lengthFeedback={lengthFeedback}
-              guessLength={guessLength}
-              isLoading={isLoading}
-            />
-          )}
-
-          {gamePhase === "spelling" && (
-            <SpellingGame
-              wordLength={wordLength}
-              currentGuess={currentGuess}
-              setCurrentGuess={setCurrentGuess}
-              submitSpelling={submitSpelling}
-              revealAnswer={revealAnswer}
-              isLoading={isLoading}
-            />
-          )}
-
-          {spellingHistory.length > 0 && (
-            <SpellingHistory
-              spellingHistory={spellingHistory}
-              lastMessage={lastMessage}
-            />
-          )}
-
-          <GameLegend />
         </div>
       </div>
+
     </div>
+
   );
 };
 

--- a/frontend/src/pages/HowToPlay.jsx
+++ b/frontend/src/pages/HowToPlay.jsx
@@ -1,10 +1,20 @@
 import React, { useContext } from 'react';
 import { Lightbulb, Volume2, SpellCheck, MousePointerClick, HelpCircle } from 'lucide-react';
 import { ThemeContext } from '../context/ThemeContext';
+import { useNavigate } from 'react-router-dom';
 
-const HowToPlay = () => {
+const HowToPlay = ({setGameState, startGame}) => {
     const { darkMode } = useContext(ThemeContext);
-    
+    const navigate = useNavigate()
+    const demoGame = async() => {
+        try {
+            await startGame("demo");
+            setGameState("demo");
+            navigate("/");
+        } catch (error) {
+            console.log("Failed to start demo game: ", error);
+        }
+    }
     const steps = [
         {
             icon: <MousePointerClick className={darkMode ? "text-blue-400" : "text-blue-600"} size={28} />,
@@ -100,6 +110,16 @@ const HowToPlay = () => {
                     ))}
                 </div>
 
+                <button
+                    onClick={demoGame}
+                    className={`inline-flex items-center justify-center px-8 py-4 text-white text-lg font-semibold rounded-2xl hover:scale-105 hover:shadow-2xl transition-all duration-300 shadow-lg disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100 disabled:hover:shadow-lg active:scale-95 min-w-48 group ${
+                        darkMode 
+                        ? "bg-blue-700 hover:bg-blue-600" 
+                        : "bg-blue-600 hover:bg-blue-700"
+                    }`}
+                    >
+                        Try Demo Round
+                    </button>
                 {/* Color Guide */}
                 <div>
                     <h3 className={`text-2xl font-bold mb-6 text-center transition-colors duration-300 hover:text-blue-600 ${


### PR DESCRIPTION
## Description:
This PR implements the feature requested in issue #84 (GSSOC’25), adding a Demo Round button on the HowToPlay page.

Users can now try a practice round to understand the gameplay without impacting their actual scores or leaderboard standing. This improves the onboarding experience and helps new players get familiar with the game mechanics in a safe environment.
